### PR TITLE
Issue0009

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 
 !src
 !ipcore_dir
-
+*.v~

--- a/font5_base.xise
+++ b/font5_base.xise
@@ -17,7 +17,7 @@
   <files>
     <file xil_pn:name="src/verilog/synthesis/ADC_block.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="34"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="34"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="35"/>
     </file>
     <file xil_pn:name="src/verilog/synthesis/align_monitor.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="12"/>
@@ -25,15 +25,15 @@
     </file>
     <file xil_pn:name="src/verilog/synthesis/AmpTrig.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="33"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="33"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="34"/>
     </file>
     <file xil_pn:name="src/verilog/synthesis/antiDroopIIR.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="32"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="32"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="33"/>
     </file>
     <file xil_pn:name="src/verilog/synthesis/auxOut_select.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="37"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="38"/>
     </file>
     <file xil_pn:name="src/verilog/synthesis/bench.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -57,7 +57,7 @@
     </file>
     <file xil_pn:name="src/verilog/synthesis/DCM_config_rst.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="36"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="37"/>
     </file>
     <file xil_pn:name="src/verilog/synthesis/delay_calc.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="9"/>
@@ -76,11 +76,11 @@
     </file>
     <file xil_pn:name="src/verilog/synthesis/FONT5_base.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="35"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="35"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="36"/>
     </file>
     <file xil_pn:name="src/verilog/synthesis/FONT5_base_xlnx.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="39"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="40"/>
     </file>
     <file xil_pn:name="src/verilog/synthesis/Interleaver.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="26"/>
@@ -140,7 +140,7 @@
     </file>
     <file xil_pn:name="ipcore_dir/DCM1.xaw" xil_pn:type="FILE_XAW">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="38"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="39"/>
     </file>
     <file xil_pn:name="ipcore_dir/DCM2.xaw" xil_pn:type="FILE_XAW">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -184,7 +184,7 @@
     </file>
     <file xil_pn:name="src/verilog/synthesis/boardSynchroniser3.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="31"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="31"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="32"/>
     </file>
     <file xil_pn:name="src/verilog/synthesis/UART_RX_TB.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -231,6 +231,10 @@
     <file xil_pn:name="src/verilog/simulation/font5_base_TB.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="119"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
+    </file>
+    <file xil_pn:name="src/verilog/synthesis/chanOffsetMUX.v" xil_pn:type="FILE_VERILOG">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="79"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="31"/>
     </file>
     <file xil_pn:name="ipcore_dir/DAQ_MEM.xise" xil_pn:type="FILE_COREGENISE">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
@@ -580,6 +584,7 @@
     <!-- Do not hand-edit this section, as it will be overwritten when the    -->
     <!-- project is analyzed based on files automatically identified as       -->
     <!-- include files.                                                       -->
+    <file xil_pn:name="src/verilog/synthesis/bits_to_fit.v" xil_pn:type="FILE_VERILOG"/>
     <file xil_pn:name="src/verilog/synthesis/definitions.vh" xil_pn:type="FILE_VERILOG"/>
     <file xil_pn:name="src/verilog/synthesis/ctrl_regs.v" xil_pn:type="FILE_VERILOG"/>
     <file xil_pn:name="src/verilog/synthesis/ctrl_regs_init_CTF.v" xil_pn:type="FILE_VERILOG"/>
@@ -587,7 +592,6 @@
     <file xil_pn:name="src/verilog/synthesis/DRDY_IDELAY_inst.v" xil_pn:type="FILE_VERILOG"/>
     <file xil_pn:name="src/verilog/synthesis/DATA_IBUFDS_inst.v" xil_pn:type="FILE_VERILOG"/>
     <file xil_pn:name="src/verilog/synthesis/DATA_IODELAY_inst.v" xil_pn:type="FILE_VERILOG"/>
-    <file xil_pn:name="src/verilog/synthesis/bits_to_fit.v" xil_pn:type="FILE_VERILOG"/>
   </autoManagedFiles>
 
 </project>

--- a/ipcore_dir/DAQ_MEM.gise
+++ b/ipcore_dir/DAQ_MEM.gise
@@ -27,27 +27,6 @@
     <file xil_pn:fileType="FILE_VEO" xil_pn:name="DAQ_MEM.veo" xil_pn:origination="imported"/>
   </files>
 
-  <transforms xmlns="http://www.xilinx.com/XMLSchema">
-    <transform xil_pn:end_ts="1491595347" xil_pn:name="TRAN_copyInitialToXSTAbstractSynthesis" xil_pn:start_ts="1491595347">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1491595347" xil_pn:name="TRAN_schematicsToHdl" xil_pn:prop_ck="-5842364284022654535" xil_pn:start_ts="1491595347">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1491595347" xil_pn:name="TRAN_regenerateCores" xil_pn:prop_ck="-4886394891324157995" xil_pn:start_ts="1491595347">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1491595347" xil_pn:name="TRAN_SubProjectAbstractToPreProxy" xil_pn:start_ts="1491595347">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1491595347" xil_pn:name="TRAN_xawsTohdl" xil_pn:prop_ck="2756340700594662603" xil_pn:start_ts="1491595347">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-  </transforms>
+  <transforms xmlns="http://www.xilinx.com/XMLSchema"/>
 
 </generated_project>

--- a/ipcore_dir/LUTROM.gise
+++ b/ipcore_dir/LUTROM.gise
@@ -27,27 +27,6 @@
     <file xil_pn:fileType="FILE_VEO" xil_pn:name="LUTROM.veo" xil_pn:origination="imported"/>
   </files>
 
-  <transforms xmlns="http://www.xilinx.com/XMLSchema">
-    <transform xil_pn:end_ts="1491595347" xil_pn:name="TRAN_copyInitialToXSTAbstractSynthesis" xil_pn:start_ts="1491595347">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1491595347" xil_pn:name="TRAN_schematicsToHdl" xil_pn:prop_ck="5021949687067077704" xil_pn:start_ts="1491595347">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1491595347" xil_pn:name="TRAN_regenerateCores" xil_pn:prop_ck="6383988805872622564" xil_pn:start_ts="1491595347">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1491595347" xil_pn:name="TRAN_SubProjectAbstractToPreProxy" xil_pn:start_ts="1491595347">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1491595347" xil_pn:name="TRAN_xawsTohdl" xil_pn:prop_ck="1928563036835562778" xil_pn:start_ts="1491595347">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-  </transforms>
+  <transforms xmlns="http://www.xilinx.com/XMLSchema"/>
 
 </generated_project>

--- a/src/constraints/FONT5_base.ucf
+++ b/src/constraints/FONT5_base.ucf
@@ -464,4 +464,5 @@ NET "diginput2"  LOC = "AG5";
 
 ## ADVANCED TIMING CONSTRIANTS ##
 NET "FONT5_base_top/loop/opMode*" TIG; # Slow MUX_SEL control signal?
+NET "FONT5_base_top/chan*_offset*" TIG;
 #NET "iddr*_ce*" TIG;

--- a/src/constraints/FONT5_base.ucf
+++ b/src/constraints/FONT5_base.ucf
@@ -464,5 +464,5 @@ NET "diginput2"  LOC = "AG5";
 
 ## ADVANCED TIMING CONSTRIANTS ##
 NET "FONT5_base_top/loop/opMode*" TIG; # Slow MUX_SEL control signal?
-NET "FONT5_base_top/chan*_offset*" TIG;
+#NET "FONT5_base_top/chan*_offset*" TIG;
 #NET "iddr*_ce*" TIG;

--- a/src/verilog/synthesis/antiDroopIIR.v
+++ b/src/verilog/synthesis/antiDroopIIR.v
@@ -5,7 +5,7 @@ module antiDroopIIR (
 	input signed [6:0] tapWeight,
 	input accClr_en,
 	//input oflowClr,
-	output reg oflowDetect = 1'd0,
+	(* shreg_extract = "no" *) output reg oflowDetect = 1'd0,
 	//output reg signed [12:0] dout = 13'sd0);
 	output reg signed [15:0] dout = 16'sd0);
 

--- a/src/verilog/synthesis/antiDroopIIR_16.v
+++ b/src/verilog/synthesis/antiDroopIIR_16.v
@@ -5,7 +5,7 @@ module antiDroopIIR_16 (
 	input signed [6:0] tapWeight,
 	input accClr_en,
 	//input oflowClr,
-	output reg oflowDetect = 1'd0,
+	(* shreg_extract = "no" *) output reg oflowDetect = 1'd0,
 	output reg signed [15:0] dout = 16'sd0);
 
 parameter IIR_scale = 15; // define the scaling factor for the IIR multiplier, eg for 0.002 (din = 63, IIR_scale = 15).

--- a/src/verilog/synthesis/chanOffsetMUX.v
+++ b/src/verilog/synthesis/chanOffsetMUX.v
@@ -1,0 +1,149 @@
+module chanOffsetMUX (	
+	input clk,
+	input signed [12:0] chanOffset,
+	input [3:0] chanOffsetSel,
+	output reg signed [12:0] chan1_offset = 13'sd0, // program static offsets here!
+	output reg signed [12:0] chan2_offset = 13'sd0,
+	output reg signed [12:0] chan3_offset = 13'sd0,
+	output reg signed [12:0] chan4_offset = 13'sd0,
+	output reg signed [12:0] chan5_offset = 13'sd0,
+	output reg signed [12:0] chan6_offset = 13'sd0,
+	output reg signed [12:0] chan7_offset = 13'sd0,
+	output reg signed [12:0] chan8_offset = 13'sd0,
+	output reg signed [12:0] chan9_offset = 13'sd0
+	);
+
+(* async_reg = "TRUE" *) reg signed [12:0] chanOffset_a = 13'sd0, chanOffset_b = 13'sd0;
+(* async_reg = "TRUE" *) reg [3:0] chanOffsetSel_a = 4'h0, chanOffsetSel_b = 4'h0;
+ 
+always @(posedge clk) begin
+	chanOffset_a <= chanOffset;
+	chanOffset_b <= chanOffset_a;
+	chanOffsetSel_a <= chanOffsetSel;
+	chanOffsetSel_b <= chanOffsetSel_a;
+	/*chan1_offset <= chan1_offset;
+	chan2_offset <= chan2_offset;
+	chan3_offset <= chan3_offset;
+	chan4_offset <= chan4_offset;
+	chan5_offset <= chan5_offset;
+	chan6_offset <= chan6_offset;
+	chan7_offset <= chan7_offset;
+	chan8_offset <= chan8_offset;
+	chan9_offset <= chan9_offset;*/
+
+	(* full_case, parallel_case *)
+	case (chanOffsetSel_b)
+	4'h1: begin
+		chan1_offset <= chanOffset_b;
+		chan2_offset <= chan2_offset;
+		chan3_offset <= chan3_offset;
+		chan4_offset <= chan4_offset;
+		chan5_offset <= chan5_offset;
+		chan6_offset <= chan6_offset;
+		chan7_offset <= chan7_offset;
+		chan8_offset <= chan8_offset;
+		chan9_offset <= chan9_offset;
+		end
+	4'h2: begin
+		chan1_offset <= chan1_offset;
+		chan2_offset <= chanOffset_b;
+		chan3_offset <= chan3_offset;
+		chan4_offset <= chan4_offset;
+		chan5_offset <= chan5_offset;
+		chan6_offset <= chan6_offset;
+		chan7_offset <= chan7_offset;
+		chan8_offset <= chan8_offset;
+		chan9_offset <= chan9_offset;
+		end
+	4'h3: begin
+		chan1_offset <= chan1_offset;
+		chan2_offset <= chan2_offset;
+		chan3_offset <= chanOffset_b;
+		chan4_offset <= chan4_offset;
+		chan5_offset <= chan5_offset;
+		chan6_offset <= chan6_offset;
+		chan7_offset <= chan7_offset;
+		chan8_offset <= chan8_offset;
+		chan9_offset <= chan9_offset;
+		end
+	4'h4: begin
+		chan1_offset <= chan1_offset;
+		chan2_offset <= chan2_offset;
+		chan3_offset <= chan3_offset;
+		chan4_offset <= chanOffset_b;
+		chan5_offset <= chan5_offset;
+		chan6_offset <= chan6_offset;
+		chan7_offset <= chan7_offset;
+		chan8_offset <= chan8_offset;
+		chan9_offset <= chan9_offset;
+		end
+	4'h5: begin
+		chan1_offset <= chan1_offset;
+		chan2_offset <= chan2_offset;
+		chan3_offset <= chan3_offset;
+		chan4_offset <= chan4_offset;
+		chan5_offset <= chanOffset_b;
+		chan6_offset <= chan6_offset;
+		chan7_offset <= chan7_offset;
+		chan8_offset <= chan8_offset;
+		chan9_offset <= chan9_offset;
+		end
+	4'h6: begin
+		chan1_offset <= chan1_offset;
+		chan2_offset <= chan2_offset;
+		chan3_offset <= chan3_offset;
+		chan4_offset <= chan4_offset;
+		chan5_offset <= chan5_offset;
+		chan6_offset <= chanOffset_b;
+		chan7_offset <= chan7_offset;
+		chan8_offset <= chan8_offset;
+		chan9_offset <= chan9_offset;
+		end
+	4'h7: begin
+		chan1_offset <= chan1_offset;
+		chan2_offset <= chan2_offset;
+		chan3_offset <= chan3_offset;
+		chan4_offset <= chan4_offset;
+		chan5_offset <= chan5_offset;
+		chan6_offset <= chan6_offset;
+		chan7_offset <= chanOffset_b;
+		chan8_offset <= chan8_offset;
+		chan9_offset <= chan9_offset;
+		end
+	4'h8: begin
+		chan1_offset <= chan1_offset;
+		chan2_offset <= chan2_offset;
+		chan3_offset <= chan3_offset;
+		chan4_offset <= chan4_offset;
+		chan5_offset <= chan5_offset;
+		chan6_offset <= chan6_offset;
+		chan7_offset <= chan7_offset;
+		chan8_offset <= chanOffset_b;
+		chan9_offset <= chan9_offset;
+		end
+	4'h9: begin
+		chan1_offset <= chan1_offset;
+		chan2_offset <= chan2_offset;
+		chan3_offset <= chan3_offset;
+		chan4_offset <= chan4_offset;
+		chan5_offset <= chan5_offset;
+		chan6_offset <= chan6_offset;
+		chan7_offset <= chan7_offset;
+		chan8_offset <= chan8_offset;
+		chan9_offset <= chanOffset_b;
+		end
+	default: begin
+		chan1_offset <= chan1_offset;
+		chan2_offset <= chan2_offset;
+		chan3_offset <= chan3_offset;
+		chan4_offset <= chan4_offset;
+		chan5_offset <= chan5_offset;
+		chan6_offset <= chan6_offset;
+		chan7_offset <= chan7_offset;
+		chan8_offset <= chan8_offset;
+		chan9_offset <= chan9_offset;
+		end
+	endcase
+end
+
+endmodule

--- a/src/verilog/synthesis/ctrl_regs.v
+++ b/src/verilog/synthesis/ctrl_regs.v
@@ -224,7 +224,8 @@ assign DAC2_IIRtapWeight = ctrl_regs[63];
 
 //assign trig_delay = ctrl_regs[0];			
 assign trig_out1_delay = ctrl_regs[ADDROFF+1];
-assign trig_out_en = (ctrl_regs[ADDROFF+2]==0) ? 0 : 1;
+//assign trig_out_en = (ctrl_regs[ADDROFF+2]==0) ? 0 : 1;
+assign trig_out_en = ctrl_regs[ADDROFF+2][0];
 
 /*assign temp18 = ctrl_regs[4];
 assign p1_bunch1pos  = {temp18[0], ctrl_regs[3]};
@@ -261,7 +262,9 @@ assign k1_const_dac_out	= {temp28[5:0], ctrl_regs[22]};
 assign temp29 = ctrl_regs[25];
 assign k2_const_dac_out	= {temp29[5:0], ctrl_regs[24]};*/
 
-assign cr_clk2_16_edge_sel	= (ctrl_regs[ADDROFF+26]==0) ? 0 : 1;	
+//assign cr_clk2_16_edge_sel	= (ctrl_regs[ADDROFF+26]==0) ? 0 : 1;	
+assign cr_clk2_16_edge_sel	= ctrl_regs[ADDROFF+26][0];	
+
 assign cr_sample_hold_off = ctrl_regs[ADDROFF+27];
 
 //assign temp30 = ctrl_regs[29];
@@ -287,8 +290,12 @@ wire [4:0] bank3_sr_tap = ctrl_regs[ADDROFF+63][4:0];
 //wire [5:0] bank2_sr_tap = ctrl_regs[ADDROFF+62][5:0];
 //wire [5:0] bank3_sr_tap = ctrl_regs[ADDROFF+63][5:0];
 
-wire signed [12:0] chan2_offset = {ctrl_regs[ADDROFF+43][5:0], ctrl_regs[ADDROFF+42]};
-wire signed [12:0] chan5_offset = {ctrl_regs[ADDROFF+50][5:0], ctrl_regs[ADDROFF+49]};
+//wire signed [12:0] chan2_offset = {ctrl_regs[ADDROFF+43][5:0], ctrl_regs[ADDROFF+42]};
+//wire signed [12:0] chan5_offset = {ctrl_regs[ADDROFF+50][5:0], ctrl_regs[ADDROFF+49]};
+
+wire signed [12:0] chanOffset = {ctrl_regs[ADDROFF+2][6:1], ctrl_regs[ADDROFF+0]};
+wire [3:0] chanOffsetSel = ctrl_regs[ADDROFF+26][6:3];
+
 //wire signed [12:0] amp1lim = {ctrl_regs[ADDROFF+44][5:0], ctrl_regs[ADDROFF+45]};
 
 ///// GAIN STAGES //////

--- a/src/verilog/synthesis/dataRegConvert.v
+++ b/src/verilog/synthesis/dataRegConvert.v
@@ -22,10 +22,10 @@ module dataRegConvert(
     input clk,
 	 input [1:0] sr_bypass,
     input signed [12:0] din,
-	 //input signed [12:0] offset,
+	 input signed [12:0] offset,
 	 //input [5:0] sr_tap,
 	 input [4:0] sr_tap,
-    (* keep = "yes" *) output reg signed [12:0] dout = 13'sd0
+    (* keep = "yes" *) output reg signed [13:0] dout = 14'sd0
 		//output signed [12:0] dout
     );
 	 
@@ -43,6 +43,7 @@ module dataRegConvert(
 
 
 `ifdef ADDPIPEREGS reg signed [width-1:0] pipereg = BITFLIP;
+`else reg signed [width-1:0] dreg_b = 13'd0;
 `endif
 //reg signed [width-1:0] dreg_b;
 //reg signed [width-1:0] dout;
@@ -61,15 +62,16 @@ always @(posedge clk) begin
 		pipereg <= data_reg;
 		//dout <= {~pipereg[width-1], pipereg[width-2:0]};
 		//dout <= (sr_tap_b[5]) ? (data_out ^ BITFLIP) : (pipereg ^ BITFLIP);
-		dout <= (sr_bypass[0]) ? (pipereg ^ BITFLIP) : (data_out ^ BITFLIP);// + offset_b;
+		dout <= (sr_bypass[0]) ? (pipereg ^ BITFLIP) : (data_out ^ BITFLIP) + offset;
 	end 
 	`else
 		//dout <= {~data_reg[width-1], data_reg[width-2:0]};
 		//dout <= data_reg ^ BITFLIP;
 		//dout <= (sr_tap_b[5]) ? (data_out ^ BITFLIP) : (data_reg ^ BITFLIP);
-		dout <= (sr_bypass[0]) ? (data_reg ^ BITFLIP) : (data_out ^ BITFLIP);// +offset_b;
+		dreg_b <= (sr_bypass[0]) ? (data_reg ^ BITFLIP) : (data_out ^ BITFLIP);// +offset;
+		dout <= dreg_b + offset;
 	`endif
-	//dout <= dreg_b;
+	//dout <= dreg_b + offset;
 end
 `ifdef ADDPIPEREGS ShiftReg #(32, BITFLIP) DataInreg(clk, sr_bypass[1], pipereg, sr_tap, data_out);
 `else ShiftReg #(32, BITFLIP) DataInreg(clk, sr_bypass[1], data_reg, sr_tap, data_out);

--- a/src/verilog/synthesis/dataRegConvert.v
+++ b/src/verilog/synthesis/dataRegConvert.v
@@ -22,6 +22,7 @@ module dataRegConvert(
     input clk,
 	 input [1:0] sr_bypass,
     input signed [12:0] din,
+	 //input signed [12:0] offset,
 	 //input [5:0] sr_tap,
 	 input [4:0] sr_tap,
     (* keep = "yes" *) output reg signed [12:0] dout = 13'sd0
@@ -47,22 +48,26 @@ module dataRegConvert(
 //reg signed [width-1:0] dout;
 wire signed [width-1:width-13] data_out;
 
+//(* async_reg = "TRUE" *) reg signed [12:0] offset_a = 13'd0, offset_b = 13'd0;
+
 always @(posedge clk) begin
 	//sr_tap_a <= sr_tap;
 	//sr_tap_b <= sr_tap_a;
 	//sr_tap_c <= sr_tap_b;
+	//offset_b <= offset_a;
+	//offset_a <= offset;
 	data_reg <= din;
 	`ifdef ADDPIPEREGS begin
 		pipereg <= data_reg;
 		//dout <= {~pipereg[width-1], pipereg[width-2:0]};
 		//dout <= (sr_tap_b[5]) ? (data_out ^ BITFLIP) : (pipereg ^ BITFLIP);
-		dout <= (sr_bypass[0]) ? (pipereg ^ BITFLIP) : (data_out ^ BITFLIP);
+		dout <= (sr_bypass[0]) ? (pipereg ^ BITFLIP) : (data_out ^ BITFLIP);// + offset_b;
 	end 
 	`else
 		//dout <= {~data_reg[width-1], data_reg[width-2:0]};
 		//dout <= data_reg ^ BITFLIP;
 		//dout <= (sr_tap_b[5]) ? (data_out ^ BITFLIP) : (data_reg ^ BITFLIP);
-		dout <= (sr_bypass[0]) ? (data_reg ^ BITFLIP) : (data_out ^ BITFLIP);
+		dout <= (sr_bypass[0]) ? (data_reg ^ BITFLIP) : (data_out ^ BITFLIP);// +offset_b;
 	`endif
 	//dout <= dreg_b;
 end


### PR DESCRIPTION
Merging branch Issue0009 to master:

13-bit chanel offsets included on each channel. Channel de-multiplexer used to access 'channelOffset' value from the UART. Offsets added in inside DataRegConvert module - needed one extra clock cycle.

Signals also renamed from eg 'p1_xdif ...' to 'chan1' etc, for generality.