### PR TITLE
Numerous changes from 31 May - 1 June 2017 #18

### DIFF
--- a/font5_base.xise
+++ b/font5_base.xise
@@ -576,7 +576,7 @@
     <property xil_pn:name="Use Synthesis Constraints File" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="User Access Register Value" xil_pn:value="None" xil_pn:valueState="default"/>
     <property xil_pn:name="User Browsed Strategy Files" xil_pn:value="C:/Xilinx/14.7/ISE_DS/ISE/data/default.xds" xil_pn:valueState="non-default"/>
-    <property xil_pn:name="UserID Code (8 Digit Hexadecimal)" xil_pn:value="300517a1" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="UserID Code (8 Digit Hexadecimal)" xil_pn:value="030617a1" xil_pn:valueState="non-default"/>
     <property xil_pn:name="VHDL Source Analysis Standard" xil_pn:value="VHDL-93" xil_pn:valueState="default"/>
     <property xil_pn:name="Value Range Check" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Verilog 2001 Xst" xil_pn:value="true" xil_pn:valueState="default"/>
@@ -620,12 +620,12 @@
     <!-- project is analyzed based on files automatically identified as       -->
     <!-- include files.                                                       -->
     <file xil_pn:name="src/verilog/synthesis/bits_to_fit.v" xil_pn:type="FILE_VERILOG"/>
+    <file xil_pn:name="src/verilog/synthesis/ctrl_regs.v" xil_pn:type="FILE_VERILOG"/>
     <file xil_pn:name="src/verilog/synthesis/ctrl_regs_init_ATF.v" xil_pn:type="FILE_VERILOG"/>
     <file xil_pn:name="src/verilog/synthesis/DRDY_IBUFDS_inst.v" xil_pn:type="FILE_VERILOG"/>
     <file xil_pn:name="src/verilog/synthesis/DRDY_IDELAY_inst.v" xil_pn:type="FILE_VERILOG"/>
     <file xil_pn:name="src/verilog/synthesis/DATA_IBUFDS_inst.v" xil_pn:type="FILE_VERILOG"/>
     <file xil_pn:name="src/verilog/synthesis/DATA_IODELAY_inst.v" xil_pn:type="FILE_VERILOG"/>
-    <file xil_pn:name="src/verilog/synthesis/ctrl_regs.v" xil_pn:type="FILE_VERILOG"/>
   </autoManagedFiles>
 
 </project>

--- a/ipcore_dir/DAQ_MEM.gise
+++ b/ipcore_dir/DAQ_MEM.gise
@@ -27,27 +27,6 @@
     <file xil_pn:fileType="FILE_VEO" xil_pn:name="DAQ_MEM.veo" xil_pn:origination="imported"/>
   </files>
 
-  <transforms xmlns="http://www.xilinx.com/XMLSchema">
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_copyInitialToXSTAbstractSynthesis" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_schematicsToHdl" xil_pn:prop_ck="-5842364284022654535" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_regenerateCores" xil_pn:prop_ck="-4886394891324157995" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_SubProjectAbstractToPreProxy" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_xawsTohdl" xil_pn:prop_ck="2756340700594662603" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-  </transforms>
+  <transforms xmlns="http://www.xilinx.com/XMLSchema"/>
 
 </generated_project>

--- a/ipcore_dir/LUTROM.gise
+++ b/ipcore_dir/LUTROM.gise
@@ -27,27 +27,6 @@
     <file xil_pn:fileType="FILE_VEO" xil_pn:name="LUTROM.veo" xil_pn:origination="imported"/>
   </files>
 
-  <transforms xmlns="http://www.xilinx.com/XMLSchema">
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_copyInitialToXSTAbstractSynthesis" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_schematicsToHdl" xil_pn:prop_ck="5021949687067077704" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_regenerateCores" xil_pn:prop_ck="6383988805872622564" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_SubProjectAbstractToPreProxy" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_xawsTohdl" xil_pn:prop_ck="1928563036835562778" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-  </transforms>
+  <transforms xmlns="http://www.xilinx.com/XMLSchema"/>
 
 </generated_project>

--- a/ipcore_dir/lookuptable1.gise
+++ b/ipcore_dir/lookuptable1.gise
@@ -26,27 +26,6 @@
     <file xil_pn:fileType="FILE_VEO" xil_pn:name="lookuptable1.veo" xil_pn:origination="imported"/>
   </files>
 
-  <transforms xmlns="http://www.xilinx.com/XMLSchema">
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_copyInitialToXSTAbstractSynthesis" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_schematicsToHdl" xil_pn:prop_ck="-4478115457550910920" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_regenerateCores" xil_pn:prop_ck="7519978984469340820" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_SubProjectAbstractToPreProxy" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-    <transform xil_pn:end_ts="1496169659" xil_pn:name="TRAN_xawsTohdl" xil_pn:prop_ck="-1361036164369635190" xil_pn:start_ts="1496169659">
-      <status xil_pn:value="SuccessfullyRun"/>
-      <status xil_pn:value="ReadyToRun"/>
-    </transform>
-  </transforms>
+  <transforms xmlns="http://www.xilinx.com/XMLSchema"/>
 
 </generated_project>

--- a/src/constraints/FONT5_base.ucf
+++ b/src/constraints/FONT5_base.ucf
@@ -465,4 +465,14 @@ NET "diginput2"  LOC = "AG5";
 ## ADVANCED TIMING CONSTRIANTS ##
 #NET "FONT5_base_top/loop/opMode*" TIG; # Slow MUX_SEL control signal?
 #NET "FONT5_base_top/chan*_offset*" TIG;
+#NET "FONT5_base_top/ch1_dataRegConvert/dataInreg/tap_b*" TIG;
+#NET "FONT5_base_top/ch2_dataRegConvert/dataInreg/tap_b*" TIG;
+#NET "FONT5_base_top/ch3_dataRegConvert/dataInreg/tap_b*" TIG;
+#NET "FONT5_base_top/ch4_dataRegConvert/dataInreg/tap_b*" TIG;
+#NET "FONT5_base_top/ch5_dataRegConvert/dataInreg/tap_b*" TIG;
+#NET "FONT5_base_top/ch6_dataRegConvert/dataInreg/tap_b*" TIG;
+#NET "FONT5_base_top/ch7_dataRegConvert/dataInreg/tap_b*" TIG;
+#NET "FONT5_base_top/ch8_dataRegConvert/dataInreg/tap_b*" TIG;
+#NET "FONT5_base_top/ch9_dataRegConvert/dataInreg/tap_b*" TIG;
+
 #NET "iddr*_ce*" TIG;

--- a/src/verilog/synthesis/DSPCalcModule.v
+++ b/src/verilog/synthesis/DSPCalcModule.v
@@ -45,9 +45,11 @@ reg signed [14:0] delayed;
 reg signed [37:0] DSPout;
 //reg DSPoflow=1'b0;
 
+reg signed [20:0] chargeA= 21'd0;
 
 always @ (posedge clk) begin
-DSPtemp <= charge_in*signal_in;
+chargeA <= charge_in;
+DSPtemp <= chargeA*signal_in;
 //DSPtemp2=DSPtemp[24:12];   // Doesnt help timing!!!
 DSPout <= DSPtemp+{delayed, 12'b0}; // Remove 4096 factor added for LUT // delayed 25 bits, 
 pout<=DSPout[26:12];

--- a/src/verilog/synthesis/FBModule.v
+++ b/src/verilog/synthesis/FBModule.v
@@ -41,7 +41,7 @@ wire signed [16:0] bpm2_i_reg_int;
 wire signed [16:0] bpm2_q_reg_int;
 //wire dac_clk;
 reg dac_cond;
-reg signed [12:0] charge;
+//reg signed [12:0] charge;
 
 (* shreg_extract = "no" ,ASYNC_REG = "TRUE" *) reg [1:0] no_bunches_a,no_bunches;
 (* shreg_extract = "no" ,ASYNC_REG = "TRUE" *) reg [3:0] no_samples_a, no_samples;
@@ -66,7 +66,7 @@ b1_strobe_a<=b1_strobe_b;
 b1_strobe<=b1_strobe_a;
 b2_strobe_a<=b2_strobe_b;
 b2_strobe<=b2_strobe_a;
-charge<=q_signal;
+//charge<=q_signal;
 fb_en_a<=fb_en_b;
 fb_en<=fb_en_a;
 banana_corr_temp_a<=banana_corr_temp_b;
@@ -143,7 +143,8 @@ LUTCalc	LookUpTableModule(
 									  .bpm2_q_lut_addrb(bpm_lut_addrb),
 									  .bpm2_q_lut_web(bpm2_q_lut_web),
 									  .bpm2_q_lut_doutb(bpm2_q_lut_doutb),
-									  .q_signal(charge),
+									  //.q_signal(charge),
+									  .q_signal(q_signal),
 									  .bpm1_i_lut_out(g1_inv_q),
 									  .bpm1_q_lut_out(g2_inv_q),
 									  .bpm2_i_lut_out(g3_inv_q),

--- a/src/verilog/synthesis/FONT5_base.v
+++ b/src/verilog/synthesis/FONT5_base.v
@@ -155,11 +155,11 @@ reg [CR_WIDTH-1:0] ctrl_regs [0:N_CTRL_REGS-1];
 reg [CR_WIDTH-1:0] ctrl_regs_mem [0:N_CTRL_REGS-1];
 
 //`include "H:\Firmware\FONT5_base\sources\verilog\ctrl_regs.v"
-`ifdef BUILD_ATF //temporary solution until ctrl_regs module is tidied up
+//`ifdef BUILD_ATF //temporary solution until ctrl_regs module is tidied up
 	`include "ctrl_regs.v"
-`else 
-	`include "ctrl_regs_CTF.v"
-`endif 
+//`else 
+//	`include "ctrl_regs_CTF.v"
+//`endif 
 
 //`ifdef XILINX_ISIM
 //	`include "H:\Firmware\FONT5_base\sources\verilog\ctrl_regs_init_sim.v"
@@ -279,15 +279,14 @@ wire [3:0] TFSMstate;
 		.OPWIDTH(10'd1000)) bench(clk357, tb_trigOut, tb_dataOut);
 `elsif BUILD_ATF
 	wire tb_trig_out, amp1_trig, amp2_trig;
-	(* ASYNC_REG = "TRUE" *) reg trig_out_en_a = 1'b0;
-	//reg trig_out_en_b = 1'b0;
+	(* ASYNC_REG = "TRUE" *) reg trig_out_en_a = 1'b0, trig_out_en_b = 1'b0;
 	//reg trig_out_en_c = 1'b0;
 	always @ (posedge clk357) begin
 		trig_out_en_a <= trig_out_en;
-		//trig_out_en_b <= trig_out_en_a;
+		trig_out_en_b <= trig_out_en_a;
 		//trig_out_en_c <= trig_out_en_b;
-		auxOutA <= amp1_trig & trig_out_en_a;
-		auxOutB <= amp2_trig & trig_out_en_a;
+		auxOutA <= amp1_trig & trig_out_en_b;
+		auxOutB <= amp2_trig & trig_out_en_b;
 	end
 	assign tb_trigOut = 1'b0;
 `elsif BUILD_CTF
@@ -791,9 +790,15 @@ end
 //assign p1_xdif_RAM_data = (~IIRbypass_b[0]) ? p1_xdif_data_fix : p1_xdif_IIR_out;
 //assign p1_ydif_RAM_data = (~IIRbypass_b[1]) ? p1_ydif_data_fix : p1_ydif_IIR_out;
 //assign p1_sum_RAM_data = (~IIRbypass_b[2]) ? p1_sum_data_fix : p1_sum_IIR_out;
-assign chan1_RAM_data = ((~IIRbypass_b[0]) ? {chan1_data, 3'b000} : chan1_IIR_out);// + {chan1_offset, 3'b000};
-assign chan2_RAM_data = ((~IIRbypass_b[1]) ? {chan2_data, 3'b000} : chan2_IIR_out);// + {chan2_offset, 3'b000};
-assign chan3_RAM_data = ((~IIRbypass_b[2]) ? {chan3_data, 3'b000} : chan3_IIR_out);// + {chan3_offset, 3'b000};
+`ifdef BUILD_ATF
+	assign chan1_RAM_data = {chan1_data, 3'b000};
+	assign chan2_RAM_data = {chan2_data, 3'b000};
+	assign chan3_RAM_data = {chan3_data, 3'b000};
+`else
+	assign chan1_RAM_data = ((~IIRbypass_b[0]) ? {chan1_data, 3'b000} : chan1_IIR_out);// + {chan1_offset, 3'b000};
+	assign chan2_RAM_data = ((~IIRbypass_b[1]) ? {chan2_data, 3'b000} : chan2_IIR_out);// + {chan2_offset, 3'b000};
+	assign chan3_RAM_data = ((~IIRbypass_b[2]) ? {chan3_data, 3'b000} : chan3_IIR_out);// + {chan3_offset, 3'b000};
+`endif
 //assign p1_xdif_RAM_data = (~IIRbypass_b[0]) ? p1_xdif_data : p1_xdif_IIR_out;
 //assign p1_ydif_RAM_data = (~IIRbypass_b[1]) ? p1_ydif_data : p1_ydif_IIR_out;
 //assign p1_sum_RAM_data = (~IIRbypass_b[2]) ? p1_sum_data : p1_sum_IIR_out;
@@ -1020,14 +1025,19 @@ end
 //assign p2_xdif_RAM_data = (~IIRbypass_b[3]) ? p2_xdif_data_fix : p2_xdif_IIR_out;
 //assign p2_ydif_RAM_data = (~IIRbypass_b[4]) ? p2_ydif_data_fix : p2_ydif_IIR_out;
 //assign p2_sum_RAM_data = (~IIRbypass_b[5]) ? p2_sum_data_fix : p2_sum_IIR_out;
-assign chan4_RAM_data = ((~IIRbypass_b[3]) ? {chan4_data, 3'b000} : chan4_IIR_out);// + {chan4_offset, 3'b000};
-assign chan5_RAM_data = ((~IIRbypass_b[4]) ? {chan5_data, 3'b000} : chan5_IIR_out);// + {chan5_offset, 3'b000};
-//assign p2_ydif_RAM_data = (~IIRbypass_b[4]) ? {p2_ydif_data, 3'b000} : p2_ydif_IIR_out;
-assign chan6_RAM_data = ((~IIRbypass_b[5]) ? {chan6_data, 3'b000} : chan6_IIR_out);// + {chan6_offset, 3'b000};
-//assign p2_xdif_RAM_data = (~IIRbypass_b[3]) ? p2_xdif_data : p2_xdif_IIR_out;
-//assign p2_ydif_RAM_data = (~IIRbypass_b[4]) ? p2_ydif_data : p2_ydif_IIR_out;
-//assign p2_sum_RAM_data = (~IIRbypass_b[5]) ? p2_sum_data : p2_sum_IIR_out;
-
+`ifdef BUILD_ATF
+	assign chan4_RAM_data = {chan4_data, 3'b000};
+	assign chan5_RAM_data = {chan5_data, 3'b000};
+	assign chan6_RAM_data = {chan6_data, 3'b000};
+`else
+	assign chan4_RAM_data = ((~IIRbypass_b[3]) ? {chan4_data, 3'b000} : chan4_IIR_out);// + {chan4_offset, 3'b000};
+	assign chan5_RAM_data = ((~IIRbypass_b[4]) ? {chan5_data, 3'b000} : chan5_IIR_out);// + {chan5_offset, 3'b000};
+	//assign p2_ydif_RAM_data = (~IIRbypass_b[4]) ? {p2_ydif_data, 3'b000} : p2_ydif_IIR_out;
+	assign chan6_RAM_data = ((~IIRbypass_b[5]) ? {chan6_data, 3'b000} : chan6_IIR_out);// + {chan6_offset, 3'b000};
+	//assign p2_xdif_RAM_data = (~IIRbypass_b[3]) ? p2_xdif_data : p2_xdif_IIR_out;
+	//assign p2_ydif_RAM_data = (~IIRbypass_b[4]) ? p2_ydif_data : p2_ydif_IIR_out;
+	//assign p2_sum_RAM_data = (~IIRbypass_b[5]) ? p2_sum_data : p2_sum_IIR_out;
+`endif
 //assign chan4_offset_oflow = (^chan4_RAM_data[DSP_WIDTH:DSP_WIDTH-1]) ? 1'b1 : 1'b0;
 //assign chan5_offset_oflow = (^chan5_RAM_data[DSP_WIDTH:DSP_WIDTH-1]) ? 1'b1 : 1'b0;
 //assign chan6_offset_oflow = (^chan6_RAM_data[DSP_WIDTH:DSP_WIDTH-1]) ? 1'b1 : 1'b0;
@@ -1234,9 +1244,15 @@ end
 //assign p3_xdif_RAM_data = (~IIRbypass_b[6]) ? p3_xdif_data_fix : p3_xdif_IIR_out;
 //assign p3_ydif_RAM_data = (~IIRbypass_b[7]) ? p3_ydif_data_fix : p3_ydif_IIR_out;
 //assign p3_sum_RAM_data = (~IIRbypass_b[8]) ? p3_sum_data_fix : p3_sum_IIR_out;
-assign chan7_RAM_data = ((~IIRbypass_b[6]) ? {chan7_data, 3'b000} : chan7_IIR_out);// + {chan7_offset, 3'b000};
-assign chan8_RAM_data = ((~IIRbypass_b[7]) ? {chan8_data, 3'b000} : chan8_IIR_out);// + {chan8_offset, 3'b000};
-assign chan9_RAM_data = ((~IIRbypass_b[8]) ? {chan9_data, 3'b000} : chan9_IIR_out);// + {chan9_offset, 3'b000};
+`ifdef BUILD_ATF
+	assign chan7_RAM_data = {chan7_data, 3'b000};
+	assign chan8_RAM_data = {chan8_data, 3'b000};
+	assign chan9_RAM_data = {chan9_data, 3'b000};
+`else
+	assign chan7_RAM_data = ((~IIRbypass_b[6]) ? {chan7_data, 3'b000} : chan7_IIR_out);// + {chan7_offset, 3'b000};
+	assign chan8_RAM_data = ((~IIRbypass_b[7]) ? {chan8_data, 3'b000} : chan8_IIR_out);// + {chan8_offset, 3'b000};
+	assign chan9_RAM_data = ((~IIRbypass_b[8]) ? {chan9_data, 3'b000} : chan9_IIR_out);// + {chan9_offset, 3'b000};
+`endif
 //assign p3_xdif_RAM_data = (~IIRbypass_b[6]) ? p3_xdif_data : p3_xdif_IIR_out;
 //assign p3_ydif_RAM_data = (~IIRbypass_b[7]) ? p3_ydif_data : p3_ydif_IIR_out;
 //assign p3_sum_RAM_data = (~IIRbypass_b[8]) ? p3_sum_data : p3_sum_IIR_out;

--- a/src/verilog/synthesis/ShiftReg.v
+++ b/src/verilog/synthesis/ShiftReg.v
@@ -14,7 +14,7 @@ parameter INIT = 13'sd0;
 
 //reg [12:0] dsh_in [0:SRL_SIZE-1];
 
-(* shreg_extract = "no" *) reg [4:0] tap_b = 5'd2;
+(* equivalent_register_removal = "no" *) reg [4:0] tap_b = 5'd2;
 (* shreg_extract = "no" *) reg sr_bypass_b = 1'b1;
 
 //reg [12:0] dsh_out;

--- a/src/verilog/synthesis/Timing.v
+++ b/src/verilog/synthesis/Timing.v
@@ -45,9 +45,15 @@ reg [7:0] end_bunch_strb=0;
 
 
 // ***** Generate bunch strobe *****
+reg strbA = 1'b0, strbB = 1'b0, strbC = 1'b0;//, strbD =1'b0;
 
 always @ (posedge clk) begin
-LUTcond<=i==b2_strobe+3|| i== b2_strobe+sample_spacing+3;
+strbA <= (b2_strobe==i);
+strbB <= (b2_strobe+sample_spacing==i);
+strbC <= (strbA || strbB);
+//strbD <= strbC;
+LUTcond <= strbC;
+//LUTcond<=i==b2_strobe+3|| i== b2_strobe+sample_spacing+3;
 if (store_strb) begin
 i<=i+1;
 end

--- a/src/verilog/synthesis/ctrl_regs.v
+++ b/src/verilog/synthesis/ctrl_regs.v
@@ -1,348 +1,146 @@
 //****************** Control Register Assignments *************************
 
-// Declare controls as named wires
+//********* FONT5_base common CRs *****************************//
 
-//old 40 MHz
-wire [1:0] bpm_sel;
-wire [1:0] no_bunches;
-wire [3:0] no_samples;
-wire [7:0] sample_spacing;
-wire [7:0] b1_strobe;
-wire [7:0] b2_strobe;
-wire 	[1:0]		p1_align_ch_sel;	
-wire 	[1:0]		p2_align_ch_sel;
-wire 	[1:0]		p3_align_ch_sel;
-wire 	[6:0]		p1_offset_delay;
-wire 	[6:0]		p2_offset_delay;
-wire 	[6:0]		p3_offset_delay;
-wire 	[5:0]		p1_scan_delay;
-wire 	[5:0]		p2_scan_delay;
-wire 	[5:0]		p3_scan_delay;
-wire 	[5:0]		master357_delay;
-wire 	[12:0]	k1_b2_offset;
-//wire 	[12:0]	k1_b3_offset;
-wire	[2:0]		diginput1_code;
-wire	[2:0] 	diginput2_code;
-/*wire  [6:0]    k1_fir_k1;
-wire  [12:0]  	k2_b2_offset;
-wire  [12:0]  	k2_b3_offset;
-wire  [6:0]   	k2_fir_k1;
-wire				k1_bunch_strb_sel;*/
-wire [9:0] num_smpls;
-wire [8:0] num_chans;
-wire [7:0] trigSync_size;
-wire use_trigSyncExt;
-wire [1:0] cr_trig_max_cnt, cr_trig_seq_sel;
-wire empty_trig_blk, trig_blk;
-//wire run;
-wire signed [6:0] ch1_IIRtapWeight;
-wire signed [6:0] ch2_IIRtapWeight;
-wire signed [6:0] ch3_IIRtapWeight;
-wire signed [6:0] ch4_IIRtapWeight;
-wire signed [6:0] ch5_IIRtapWeight;
-wire signed [6:0] ch6_IIRtapWeight;
-wire signed [6:0] ch7_IIRtapWeight;
-wire signed [6:0] ch8_IIRtapWeight;
-wire signed [6:0] ch9_IIRtapWeight;
-wire signed [6:0] DAC1_IIRtapWeight;
-wire signed [6:0] DAC2_IIRtapWeight;
-
-wire [1:0] baud_rate;
-//wire clkPLL_sel;
-
-
-//wire IIRclr_en, IIRbypass;
-wire [10:0] IIRbypass;
-wire trig_int_en;
-//wire fastClk_sel;
-//wire				slow_clk_gate_en;
-//wire	[5:0]		k1_bunch_strb_sel;
-//wire	[5:0]		k2_bunch_strb_sel;
-
-//old 357 MHz
-//wire 	[6:0]		trig_delay;					
-wire 	[6:0]		trig_out1_delay;		
-wire 				trig_out_en;				
-/*wire 	[7:0]		p1_bunch1pos;			
-wire 	[7:0]		p1_bunch2pos;			
-wire 	[7:0]		p1_bunch3pos;			
-wire  [7:0]		p2_bunch1pos;			
-wire 	[7:0]		p2_bunch2pos;			
-wire 	[7:0]		p2_bunch3pos;		
-wire 	[7:0]		p3_bunch1pos;		
-wire 	[7:0]		p3_bunch2pos;			
-wire 	[7:0]		p3_bunch3pos;*/			
-wire 				k1_fb_on;				
-//wire 				k2_fb_on;			
-wire			 	k1_delayloop_on;			
-//wire 				k2_delayloop_on; 		
-wire 				k1_const_dac_en;			
-/*wire 				k2_const_dac_en;			
-wire 	[12:0]	k1_const_dac_out;		
-wire  [12:0]	k2_const_dac_out;	*/	
-wire 				cr_clk2_16_edge_sel;		
-wire 	[6:0]		cr_sample_hold_off;
-wire 	[11:0] 	cr_trig_delay;
-wire 	[6:0]		trig_out2_delay;
-//wire				sync_en;
-
-wire FF_en, use_strbs, DAC1phase, DAC2phase, Interleave; 
-//wire FF_en, use_strbs, DAC1phase, DAC2phase; 
-wire [9:0] start_addr, end_addr;
-wire [4:0] k1_del, k2_del;
-wire [1:0] FFOpMode;
-wire signed [12:0] k1_const, k2_const;
-//wire signed [6:0] k1_gain, k2_gain;
-
-
-assign bpm_sel=ctrl_regs[70][1:0];
-assign no_bunches=ctrl_regs[70][3:2];
-assign no_samples=ctrl_regs[71][3:0];
-assign sample_spacing=ctrl_regs[67];
-assign b1_strobe=ctrl_regs[68];
-assign b2_strobe=ctrl_regs[69];
-
-assign FF_en = ctrl_regs[43][0]; 
-assign Interleave = ctrl_regs[43][1];
-assign use_strbs = ctrl_regs[39][0]; 
-assign start_addr = {ctrl_regs[40][3:0], ctrl_regs[39][6:1]};
-assign end_addr = {ctrl_regs[41], ctrl_regs[40][6:4]};
-assign k1_del = ctrl_regs[43][6:2];
-assign k2_del = ctrl_regs[44][6:2];
-//assign k1_del = ctrl_regs[43][6:1];
-//assign k2_del = ctrl_regs[44][6:1];
-//assign FFOpMode = ctrl_regs[44][0];
-assign FFOpMode = ctrl_regs[44][1:0];
-//sign k1_const = {ctrl_regs[46][5:0], ctrl_regs[45]};
-//assign k2_const = {ctrl_regs[48][5:0], ctrl_regs[47]};
-//assign k1_const = {ctrl_regs[86][5:0], ctrl_regs[87]};
-//assign k2_const = {ctrl_regs[88][5:0], ctrl_regs[89]};
-
-//assign k1_gain = ctrl_regs[49];
-//assign k2_gain = ctrl_regs[50];
-//assign DAC1phase = ctrl_regs[46][6];
-//assign DAC2phase = ctrl_regs[48][6];
-assign DAC1phase = ctrl_regs[86][6];
-assign DAC2phase = ctrl_regs[88][6];
-
-
-//Declare temporary wires for memory bit-selects
-//wire [6:0] temp1, temp2, temp3, temp5, temp6, temp7, temp8, temp9, temp10;
-//wire [6:0] temp11, temp12, temp14, temp15, temp16, temp17;
-//wire [6:0] temp18, temp19, temp20, temp21, temp22, temp23, temp24, temp25, temp26, temp27, temp28, temp29, temp30; //, temp14;
-//wire [6:0] temp30;
-wire [6:0] temp27,temp28,temp11;
-//assign temp1 = ctrl_regs[32];
-assign p1_align_ch_sel = ctrl_regs[ADDROFF+32][1:0];
-assign baud_rate = ctrl_regs[ADDROFF+32][3:2];
+wire Interleave = ctrl_regs[43][1];
+`ifdef FASTCLK_INT
+	wire fastClk_sel = ctrl_regs[51][0];
+`endif
+wire trig_int_en = ctrl_regs[51][1];
+wire [10:0] IIRbypass = {ctrl_regs[52][5:0], ctrl_regs[51][6:2]};
+`ifdef LUTRAMreadout
+	wire LUTRAMreadout = ctrl_regs[52][6];
+`endif
+wire signed [6:0] ch1_IIRtapWeight = ctrl_regs[53];
+wire signed [6:0] ch2_IIRtapWeight = ctrl_regs[54];
+wire signed [6:0] ch3_IIRtapWeight = ctrl_regs[55];
+wire signed [6:0] ch4_IIRtapWeight = ctrl_regs[56];
+wire signed [6:0] ch5_IIRtapWeight = ctrl_regs[57];
+wire signed [6:0] ch6_IIRtapWeight = ctrl_regs[58];
+wire signed [6:0] ch7_IIRtapWeight = ctrl_regs[59];
+wire signed [6:0] ch8_IIRtapWeight = ctrl_regs[60];
+wire signed [6:0] ch9_IIRtapWeight = ctrl_regs[61];
+wire signed [12:0] chanOffset = {ctrl_regs[ADDROFF+2][6:1], ctrl_regs[ADDROFF+0]};
+wire 	[6:0] trig_out1_delay = ctrl_regs[ADDROFF+1];
+wire trig_out_en = ctrl_regs[ADDROFF+2][0];
+wire signed [12:0] k1_const = {ctrl_regs[86][5:0], ctrl_regs[87]};
+wire signed [12:0] k2_const = {ctrl_regs[88][5:0], ctrl_regs[89]};
+wire cr_clk2_16_edge_sel	= ctrl_regs[ADDROFF+26][0];
+wire [3:0] chanOffsetSel = ctrl_regs[ADDROFF+26][6:3];
+wire [6:0] cr_sample_hold_off = ctrl_regs[ADDROFF+27];
+wire [11:0] cr_trig_delay = {ctrl_regs[ADDROFF+29][4:0], ctrl_regs[ADDROFF+28]};
+wire [6:0] trig_out2_delay = ctrl_regs[ADDROFF+30];
+wire [1:0] p1_align_ch_sel = ctrl_regs[ADDROFF+32][1:0];
+wire [1:0] baud_rate = ctrl_regs[ADDROFF+32][3:2];
 `ifdef CLK357_PLL
 	wire clkPLL_sel = ctrl_regs[ADDROFF+32][4];
 `endif
 wire synch_en = ctrl_regs[ADDROFF+32][5];
 wire sync_opMode = ctrl_regs[ADDROFF+32][6];
-//assign temp2 = ctrl_regs[33];
-assign p2_align_ch_sel = ctrl_regs[ADDROFF+33][1:0];
+wire [1:0] p2_align_ch_sel = ctrl_regs[ADDROFF+33][1:0];
 wire [1:0] sync_cnt_n = ctrl_regs[ADDROFF+33][3:2];
 wire [1:0] sync_cnt_m = ctrl_regs[ADDROFF+33][5:4];
-//assign temp3 = ctrl_regs[34];
-assign p3_align_ch_sel = ctrl_regs[ADDROFF+34][1:0];
+wire [1:0] p3_align_ch_sel = ctrl_regs[ADDROFF+34][1:0];
 wire constDAC1UARTor = ctrl_regs[ADDROFF+34][2];
 wire constDAC2UARTor = ctrl_regs[ADDROFF+34][3];
+wire 	[6:0] p1_offset_delay = ctrl_regs[ADDROFF+35][6:0];
+wire 	[6:0] p2_offset_delay = ctrl_regs[ADDROFF+36][6:0];
+wire 	[6:0] p3_offset_delay = ctrl_regs[ADDROFF+37][6:0];
+wire 	[5:0] p1_scan_delay = ctrl_regs[ADDROFF+38][5:0];
+wire 	[5:0] p2_scan_delay = ctrl_regs[ADDROFF+39][5:0];
+wire 	[5:0] p3_scan_delay = ctrl_regs[ADDROFF+40][5:0];
+wire 	[5:0] master357_delay	= ctrl_regs[ADDROFF+41][5:0];
+wire	[2:0] diginput1_code = ctrl_regs[ADDROFF+46][2:0];
+wire	[2:0] diginput2_code = ctrl_regs[ADDROFF+47][2:0];
+wire [9:0] num_smpls = {ctrl_regs[ADDROFF+55], ctrl_regs[ADDROFF+56][6:4]};
+wire [8:0] num_chans = {ctrl_regs[ADDROFF+56][3:0], ctrl_regs[ADDROFF+57][6:2]};
+wire [7:0] trigSync_size = {ctrl_regs[ADDROFF+57][1:0], ctrl_regs[ADDROFF+58][6:1]};
+wire use_trigSyncExt = ctrl_regs[ADDROFF+58][0];
+wire [1:0] cr_trig_seq_sel = ctrl_regs[ADDROFF+59][6:5];
+wire [1:0] cr_trig_max_cnt = ctrl_regs[ADDROFF+59][4:3];
+wire trig_blk = ctrl_regs[ADDROFF+59][2];
+wire empty_trig_blk = ctrl_regs[ADDROFF+59][1];
+assign run = ctrl_regs[ADDROFF+59][0]; // declared as top-level output
+wire [4:0] bank1_sr_tap = ctrl_regs[ADDROFF+61][4:0];
+wire [4:0] bank2_sr_tap = ctrl_regs[ADDROFF+62][4:0];
+wire [4:0] bank3_sr_tap = ctrl_regs[ADDROFF+63][4:0];
 
-
-//assign temp5 = ctrl_regs[35];
-assign p1_offset_delay = ctrl_regs[ADDROFF+35][6:0];
-//assign temp6 = ctrl_regs[36];
-assign p2_offset_delay = ctrl_regs[ADDROFF+36][6:0];
-//assign temp7 = ctrl_regs[37];
-assign p3_offset_delay = ctrl_regs[ADDROFF+37][6:0];
-
-//assign temp8 = ctrl_regs[38];
-assign p1_scan_delay = ctrl_regs[ADDROFF+38][5:0];
-//assign temp9 = ctrl_regs[39];
-assign p2_scan_delay = ctrl_regs[ADDROFF+39][5:0];
-//assign temp10 = ctrl_regs[40];
-assign p3_scan_delay = ctrl_regs[ADDROFF+40][5:0];
-
-//assign temp17 = ctrl_regs[41];
-assign master357_delay	= ctrl_regs[ADDROFF+41][5:0];
-//
-assign temp11 = ctrl_regs[ADDROFF+43];
-assign k1_b2_offset = {temp11[5:0], ctrl_regs[ADDROFF+42]};
-
-/*assign temp12 = ctrl_regs[45];
-assign k1_b3_offset = {temp12[5:0], ctrl_regs[44]};*/
-
-assign diginput1_code = ctrl_regs[ADDROFF+46][2:0];
-assign diginput2_code = ctrl_regs[ADDROFF+47][2:0];
-
-//assign temp13 = ctrl_regs[16];
-/*assign k1_fir_k1 = ctrl_regs[48];
-
-assign temp14 = ctrl_regs[50];
-assign k2_b2_offset = {temp14[5:0], ctrl_regs[49]};
-assign temp15 = ctrl_regs[52];
-assign k2_b3_offset = {temp15[5:0], ctrl_regs[51]};
-assign k2_fir_k1 = ctrl_regs[53];
-
-assign temp16 = ctrl_regs[54];
-assign k1_bunch_strb_sel = temp16[0];
-
-*/
-
-assign num_smpls = {ctrl_regs[ADDROFF+55], ctrl_regs[ADDROFF+56][6:4]};
-assign num_chans = {ctrl_regs[ADDROFF+56][3:0], ctrl_regs[ADDROFF+57][6:2]};
-assign trigSync_size = {ctrl_regs[ADDROFF+57][1:0], ctrl_regs[ADDROFF+58][6:1]};
-assign use_trigSyncExt = ctrl_regs[ADDROFF+58][0];
-
-assign cr_trig_seq_sel = ctrl_regs[ADDROFF+59][6:5];
-assign cr_trig_max_cnt = ctrl_regs[ADDROFF+59][4:3];
-assign trig_blk = ctrl_regs[ADDROFF+59][2];
-assign empty_trig_blk = ctrl_regs[ADDROFF+59][1];
-assign run = ctrl_regs[ADDROFF+59][0];
-
-//assign IIRtapWeight = ctrl_regs[ADDROFF+60];
-//assign trig_int_en = ctrl_regs[ADDROFF+61][0];
-//assign IIRclr_en = ctrl_regs[61][0];
-//assign IIRbypass = ctrl_regs[ADDROFF+61][1];
-//assign fastClk_sel = ctrl_regs[ADDROFF+61][2];
-
-`ifdef FASTCLK_INT
-	assign fastClk_sel = ctrl_regs[51][0];
+//****************** CTF3-PFF CRs ***********************//
+`ifdef BUILD_CTF
+	wire use_strbs = ctrl_regs[39][0]; 
+	wire [9:0] start_addr = {ctrl_regs[40][3:0], ctrl_regs[39][6:1]};
+	wire [9:0] end_addr = {ctrl_regs[41], ctrl_regs[40][6:4]};
+	wire FF_en = ctrl_regs[43][0]; 
+	wire [4:0] k1_del = ctrl_regs[43][6:2];
+	wire [1:0] FFOpMode = ctrl_regs[44][1:0];
+	wire [4:0] k2_del = ctrl_regs[44][6:2];
+	///// GAIN STAGES ////// - macro may now be redundant!!!
+	`ifdef GAINRES_14 // 14-bit gain
+		wire signed [13:0] k1_gain = {ctrl_regs[37], ctrl_regs[38]};
+		wire signed [13:0] k2_gain = {ctrl_regs[45], ctrl_regs[46]};
+		wire signed [13:0] loop2_k1_gain = {ctrl_regs[47], ctrl_regs[48]};
+		wire signed [13:0] loop2_k2_gain = {ctrl_regs[49], ctrl_regs[50]};
+	`else // 7-bit gain
+		wire signed [6:0] k1_gain = ctrl_regs[37];
+		wire signed [6:0] k2_gain = ctrl_regs[45];
+		wire signed [6:0] loop2_k1_gain = ctrl_regs[47];
+		wire signed [6:0] loop2_k2_gain = ctrl_regs[49];
 `endif
-assign trig_int_en = ctrl_regs[51][1];
-assign IIRbypass = {ctrl_regs[52][5:0], ctrl_regs[51][6:2]};
-`ifdef LUTRAMreadout
-	wire LUTRAMreadout = ctrl_regs[52][6];
-`endif
-
-assign ch1_IIRtapWeight = ctrl_regs[53];
-assign ch2_IIRtapWeight = ctrl_regs[54];
-assign ch3_IIRtapWeight = ctrl_regs[55];
-assign ch4_IIRtapWeight = ctrl_regs[56];
-assign ch5_IIRtapWeight = ctrl_regs[57];
-assign ch6_IIRtapWeight = ctrl_regs[58];
-assign ch7_IIRtapWeight = ctrl_regs[59];
-assign ch8_IIRtapWeight = ctrl_regs[60];
-assign ch9_IIRtapWeight = ctrl_regs[61];
-assign DAC1_IIRtapWeight = ctrl_regs[62];
-assign DAC2_IIRtapWeight = ctrl_regs[63];
-
-
-//assign temp17 = ctrl_regs[23];
-//assign k2_bunch_strb_sel = temp17[5:0];
-
-//assign temp17 = ctrl_regs[31];
-//assign slow_clk_gate_en = temp17[0];
-
-//wire [6:0] temp1, temp2, temp3, temp4, temp5, temp6, temp7, temp8, temp9, temp10, temp11, temp12, temp13;//, temp14;
-
-//assign trig_delay = ctrl_regs[0];			
-assign trig_out1_delay = ctrl_regs[ADDROFF+1];
-//assign trig_out_en = (ctrl_regs[ADDROFF+2]==0) ? 0 : 1;
-assign trig_out_en = ctrl_regs[ADDROFF+2][0];
-
-/*assign temp18 = ctrl_regs[4];
-assign p1_bunch1pos  = {temp18[0], ctrl_regs[3]};
-assign temp19 = ctrl_regs[6];
-assign p1_bunch2pos  = {temp19[0], ctrl_regs[5]};
-assign temp20 = ctrl_regs[8];
-assign p1_bunch3pos  = {temp20[0], ctrl_regs[7]};
-
-assign temp21 = ctrl_regs[10];
-assign p2_bunch1pos  = {temp21[0], ctrl_regs[9]};
-assign temp22 = ctrl_regs[12];
-assign p2_bunch2pos  = {temp22[0], ctrl_regs[11]};
-assign temp23 = ctrl_regs[14];
-assign p2_bunch3pos  = {temp23[0], ctrl_regs[13]};
-
-assign temp24 = ctrl_regs[16];
-assign p3_bunch1pos  = {temp24[0], ctrl_regs[15]};
-assign temp25 = ctrl_regs[18];
-assign p3_bunch2pos  = {temp25[0], ctrl_regs[17]};
-assign temp26 = ctrl_regs[20];
-assign p3_bunch3pos  = {temp26[0], ctrl_regs[19]};*/
-		
-assign temp27 = ctrl_regs[ADDROFF+21];
-assign k1_fb_on = temp27[0];				
-//assign k2_fb_on = temp27[1];	*/			
-assign k1_delayloop_on = temp27[2];			
-/*assign k2_delayloop_on = temp27[3]; */			
-assign k1_const_dac_en = temp27[4];			
-assign k2_const_dac_en = temp27[5];
-			
-assign temp28 = ctrl_regs[23];
-//assign k1_const_dac_out	= {temp28[5:0], ctrl_regs[22]};
-assign k1_const	= {temp28[5:0], ctrl_regs[22]};
-
-/*assign temp29 = ctrl_regs[25];
-assign k2_const_dac_out	= {temp29[5:0], ctrl_regs[24]};*/
-
-//assign cr_clk2_16_edge_sel	= (ctrl_regs[ADDROFF+26]==0) ? 0 : 1;	
-assign cr_clk2_16_edge_sel	= ctrl_regs[ADDROFF+26][0];	
-
-assign cr_sample_hold_off = ctrl_regs[ADDROFF+27];
-
-//assign temp30 = ctrl_regs[29];
-assign cr_trig_delay = {ctrl_regs[ADDROFF+29][4:0], ctrl_regs[ADDROFF+28]};
-
-assign trig_out2_delay = ctrl_regs[ADDROFF+30];
-
-//assign temp14 = ctrl_regs[31];
-//assign sync_en = temp14[0];
-
+wire signed [6:0] DAC1_IIRtapWeight = ctrl_regs[62];
+wire signed [6:0] DAC2_IIRtapWeight = ctrl_regs[63];
+wire DAC1phase = ctrl_regs[86][6];
+wire DAC2phase = ctrl_regs[88][6];
 wire useDiode = ctrl_regs[ADDROFF+60][0];
 wire [1:0] oflowMode = ctrl_regs[ADDROFF+60][2:1];
 wire diodeGating = ctrl_regs[ADDROFF+60][3];
 wire loop2_useDiode = ctrl_regs[ADDROFF+60][4];
 wire loop2_diodeGating = ctrl_regs[ADDROFF+60][5];
+`endif
+//****************** ATF2-FB CRs ************************//
+`ifdef BUILD_ATF
+	/*
+	wire [1:0] bpm_sel=ctrl_regs[70][1:0]; // move to CR90 [2:1]
+	wire [1:0] no_bunches=ctrl_regs[70][3:2]; // suggest constant =1
+	wire [3:0] no_samples=ctrl_regs[71][3:0]; // suggest use CR124 [3:0]
+	wire [7:0] sample_spacing=ctrl_regs[67]; // suggest constant - not needed for 2 bunch!
+	wire [7:0] b1_strobe=ctrl_regs[68]; //use p1b1
+	wire [7:0] b2_strobe=ctrl_regs[69]; //use p3sum(ch9)b1
+	*/
+	wire [1:0] bpm_sel=ctrl_regs[90][2:1];
+	wire [1:0] no_bunches=ctrl_regs[124][5:4];
+	wire [7:0] sample_spacing={ctrl_regs[124][6], ctrl_regs[118]};
+	//localparam [1:0] no_bunches = 2'd1; //124
+	//localparam [7:0] sample_spacing = 8'd100; //124 + 118
+	wire [3:0] no_samples = ctrl_regs[124][3:0]; //124
+	wire 	[7:0] b1_strobe = {ctrl_regs[ADDROFF+4][0], ctrl_regs[ADDROFF+3]};
+	wire 	[7:0] b2_strobe = {ctrl_regs[ADDROFF+20][0], ctrl_regs[ADDROFF+19]};
 
-
-wire [4:0] bank1_sr_tap = ctrl_regs[ADDROFF+61][4:0];
-wire [4:0] bank2_sr_tap = ctrl_regs[ADDROFF+62][4:0];
-wire [4:0] bank3_sr_tap = ctrl_regs[ADDROFF+63][4:0];
-
-//wire [5:0] bank1_sr_tap = ctrl_regs[ADDROFF+61][5:0];
-//wire [5:0] bank2_sr_tap = ctrl_regs[ADDROFF+62][5:0];
-//wire [5:0] bank3_sr_tap = ctrl_regs[ADDROFF+63][5:0];
-
-//wire signed [12:0] chan2_offset = {ctrl_regs[ADDROFF+43][5:0], ctrl_regs[ADDROFF+42]};
-//wire signed [12:0] chan5_offset = {ctrl_regs[ADDROFF+50][5:0], ctrl_regs[ADDROFF+49]};
-
-wire signed [12:0] chanOffset = {ctrl_regs[ADDROFF+2][6:1], ctrl_regs[ADDROFF+0]};
-wire [3:0] chanOffsetSel = ctrl_regs[ADDROFF+26][6:3];
-
-//wire signed [12:0] amp1lim = {ctrl_regs[ADDROFF+44][5:0], ctrl_regs[ADDROFF+45]};
-
-///// GAIN STAGES //////
-
-//   7-bit //
-
-/*wire [6:0] k1_gain = ctrl_regs[49];
-wire [6:0] k2_gain = ctrl_regs[50];
-wire [6:0] loop2_k1_gain = ctrl_regs[37];
-wire [6:0] loop2_k2_gain = ctrl_regs[38];*/
-
-// 14-bit ////
-`ifdef GAINRES_14
-//wire [13:0] k1_gain = {ctrl_regs[49], ctrl_regs[86]};
-//wire [13:0] k2_gain = {ctrl_regs[50], ctrl_regs[87]};
-//wire [13:0] loop2_k1_gain = {ctrl_regs[37], ctrl_regs[88]};
-//wire [13:0] loop2_k2_gain = {ctrl_regs[38], ctrl_regs[89]};
-wire [13:0] k1_gain = {ctrl_regs[37], ctrl_regs[38]};
-wire [13:0] k2_gain = {ctrl_regs[45], ctrl_regs[46]};
-wire [13:0] loop2_k1_gain = {ctrl_regs[47], ctrl_regs[48]};
-wire [13:0] loop2_k2_gain = {ctrl_regs[49], ctrl_regs[50]};
-`else // 7-bit gain
-//wire [6:0] k1_gain = ctrl_regs[49];
-//wire [6:0] k2_gain = ctrl_regs[50];
-//wire [6:0] loop2_k1_gain = ctrl_regs[37];
-//wire [6:0] loop2_k2_gain = ctrl_regs[38];
-wire [6:0] k1_gain = ctrl_regs[37];
-wire [6:0] k2_gain = ctrl_regs[45];
-wire [6:0] loop2_k1_gain = ctrl_regs[47];
-wire [6:0] loop2_k2_gain = ctrl_regs[49];
+	wire FF_en = ctrl_regs[ADDROFF+21][0];				
+	//wire k2_fb_on = ctrl_regs[ADDROFF+21][1];	
+	wire k1_delayloop_on = ctrl_regs[ADDROFF+21][2];			
+	//wire k2_delayloop_on = ctrl_regs[ADDROFF+21][3];	
+	wire k1_const_dac_en = ctrl_regs[ADDROFF+21][4];			
+	//wire k2_const_dac_en = ctrl_regs[ADDROFF+21][5];
+	wire 	[12:0] k1_b2_offset = {ctrl_regs[ADDROFF+43][5:0], ctrl_regs[ADDROFF+42]};
 `endif
 
+//*************** Legacy ATF CRs (Reserved) *************//
 
-
+/*
+wire 	[7:0] p1_bunch1pos  = {ctrl_regs[4][0], ctrl_regs[3]};
+wire 	[7:0] p1_bunch2pos  = {ctrl_regs[6][0], ctrl_regs[5]};
+wire 	[7:0] p1_bunch3pos  = {ctrl_regs[8][0], ctrl_regs[7]};
+wire 	[7:0] p2_bunch1pos  = {ctrl_regs[10][0], ctrl_regs[9]};
+wire 	[7:0] p2_bunch2pos  = {ctrl_regs[12][0], ctrl_regs[11]};
+wire 	[7:0] p2_bunch3pos  = {ctrl_regs[14][0], ctrl_regs[13]};
+wire 	[7:0] p3_bunch1pos  = {ctrl_regs[16][0], ctrl_regs[15]};
+wire 	[7:0] p3_bunch2pos  = {ctrl_regs[18][0], ctrl_regs[17]};
+wire 	[7:0] p3_bunch3pos  = {ctrl_regs[20][0], ctrl_regs[19]};
+wire 	[12:0] k1_b3_offset = {ctrl_regs[45][5:0], ctrl_regs[44]};
+wire  [6:0] k1_fir_k1 = ctrl_regs[48];
+wire  [12:0] k2_b2_offset = {ctrl_regs[50][5:0], ctrl_regs[49]};
+wire  [12:0] k2_b3_offset = {ctrl_regs[52][5:0], ctrl_regs[51]};
+wire  [6:0] k2_fir_k1 = ctrl_regs[53];
+wire k1_bunch_strb_sel = ctrl_regs[54][0];
+*/
+//wire signed [12:0] amp1lim = {ctrl_regs[ADDROFF+44][5:0], ctrl_regs[ADDROFF+45]};

--- a/src/verilog/synthesis/ctrl_regs_init_ATF.v
+++ b/src/verilog/synthesis/ctrl_regs_init_ATF.v
@@ -55,8 +55,8 @@ initial begin
 		ctrl_regs_mem[124] = 7'b0001101; // diodeGating = 1; oflowMode = 2(saturate); useDiode = 1;
 	`else
 		ctrl_regs[96] = 7'd8; // Baud_rate 460.8 kbps
-		ctrl_regs[110] = 7'd8; ///DigInA threshold
-		ctrl_regs[111] = 7'd8; ///DigInB threshold		
+		ctrl_regs[110] = 7'd4; ///DigInA threshold
+		ctrl_regs[111] = 7'd4; ///DigInB threshold		
 		ctrl_regs[119] = 7'b0010100; // top seven bits of ten-bit decimal "164"
 		ctrl_regs[120] = 7'b1001111; // [bottom three bits of above,  top four bits of channel select (ones hot)]
 		ctrl_regs[121] = 7'b1111110; // [bottom five bits of channel select (ones hot), top two bits of eight-bit decimal "164"
@@ -65,8 +65,8 @@ initial begin
 		ctrl_regs[124] = 7'b0001101; // diodeGating = 1; oflowMode = 2(saturate); useDiode = 1;
 		
 		ctrl_regs_mem[96] = 7'd8; // Baud_rate 460.8 kbps
-		ctrl_regs_mem[110]= 7'd8; ///DigInA threshold
-		ctrl_regs_mem[111]= 7'd8; ///DigInB threshold		
+		ctrl_regs_mem[110]= 7'd4; ///DigInA threshold
+		ctrl_regs_mem[111]= 7'd4; ///DigInB threshold		
 		ctrl_regs_mem[119] = 7'b0010100; // top seven bits of ten-bit decimal "164"
 		ctrl_regs_mem[120] = 7'b1001111; // [bottom three bits of above,  top four bits of channel select (ones hot)]
 		ctrl_regs_mem[121] = 7'b1111110; // [bottom five bits of channel select (ones hot), top two bits of eight-bit decimal "164"

--- a/src/verilog/synthesis/trigger_divider.v
+++ b/src/verilog/synthesis/trigger_divider.v
@@ -37,19 +37,43 @@ module trigger_divider(
 	 output reg pile_up
     );
 
-// Input trigger and signal form UART are all async 
-reg trig_blk_a = 1'b0, trig_blk_b = 1'b0;
-reg empty_trig_blk_a = 1'b0, empty_trig_blk_b = 1'b0;
+// Input trigger and signals from UART are all async 
+(* ASYNC_REG = "TRUE" *) reg trig_blk_a = 1'b0, trig_blk_b = 1'b0;
+(* ASYNC_REG = "TRUE" *) reg empty_trig_blk_a = 1'b0, empty_trig_blk_b = 1'b0;
 (* IOB = "TRUE" *) reg trig_a = 1'b0;
-reg trig_b = 1'b0, trig_c = 1'b0, trig_d = 1'b0;
-reg [1:0] trig_max_cnt_a = 2'd0, trig_max_cnt_b = 2'd0;
-reg [1:0] trig_seq_sel_a= 2'd0, trig_seq_sel_b = 2'd0;
-reg trig_int_en_a = 1'b0, trig_int_en_b = 1'b0;
-(* shreg_extract = "no" *) reg pulse_ctr_rst= 1'b0, pulse_ctr_rst_a = 1'b0;
+(* ASYNC_REG = "TRUE" *) reg trig_b = 1'b0, trig_c = 1'b0;
+reg trig_d = 1'b0;
+(* ASYNC_REG = "TRUE" *) reg [1:0] trig_max_cnt_a = 2'd0, trig_max_cnt_b = 2'd0;
+(* ASYNC_REG = "TRUE" *) reg [1:0] trig_seq_sel_a= 2'd0, trig_seq_sel_b = 2'd0;
+(* ASYNC_REG = "TRUE" *) reg trig_int_en_a = 1'b0, trig_int_en_b = 1'b0;
+(* ASYNC_REG = "TRUE" *) reg pulse_ctr_rst= 1'b0, pulse_ctr_rst_a = 1'b0;
 wire trig_mux = (trig_int_en_b) ? trig_int : trig_b;
-(* shreg_extract = "no" *) reg trig_rdy_a= 1'b0, trig_rdy_b = 1'b0, trig_rdy_c= 1'b0, run_a= 1'b0, run_b  = 1'b0;
+(* ASYNC_REG = "TRUE" *) reg trig_rdy_a= 1'b0, trig_rdy_b = 1'b0;
+reg trig_rdy_c= 1'b0;
+(* ASYNC_REG = "TRUE" *) reg run_a = 1'b0, run_b  = 1'b0;
 reg blocked = 1'b0;
 //wire unblock;
+//wire trig_edge;
+reg trig_edge = 1'b0;
+
+`define TRIG_DISARM
+
+reg disarm = 1'b0;
+`ifdef TRIG_DISARM // dis-arm trigger for ~700 ns following trigger edge
+	localparam DISARM_TC = 9'd511;
+	reg [7:0] trig_arm_ctr = 8'd0;
+	
+	
+	always @(posedge clk) begin
+		if (disarm) begin
+			trig_arm_ctr <= trig_arm_ctr + 1'b1;
+			disarm <= (DISARM_TC == trig_arm_ctr) ? 1'b0 : disarm;
+		end else begin
+			trig_arm_ctr <= trig_arm_ctr;
+			disarm <= trig_edge;
+		end
+	end
+`endif
 			
 always @(posedge clk) begin
 	run_a <= run;
@@ -76,7 +100,6 @@ end
 
 //trigger counter
 reg [1:0] trig_ctr = 2'd0;
-wire trig_edge;
 
 always @(posedge clk) begin
 	if (trig_edge && (trig_ctr==trig_max_cnt_b)) trig_ctr <= 0;
@@ -110,11 +133,12 @@ end
 
 //wire trig_rdy_
 	
-assign trig_edge = trig_c & ~trig_d;
+//assign trig_edge = (disarm) ? 1'b0: trig_c & ~trig_d;
 //assign unblock = trig_rdy_c & ~ trig_rdy_d;
 
 //pulse counter
 always @(posedge clk) begin
+	trig_edge <= (disarm) ? 1'b0 : trig_c & ~trig_d;
 	// NB pile_up needs re-writing - logic for blocked and pile_up should be the same
 	if (trig_edge) pile_up <= (trig_rdy_c) ? 1'b0 : 1'b1;
 	else pile_up <= pile_up;


### PR DESCRIPTION
Meets timing, but does not work!
513 w; 2.795/5.108; 386/85 synth; 98 i

Files changed:
DSPModule.v -> added extra register 'chargeA' ahead of MULT
FBmodule.v -> removed 'charge' register to compensate for above
FONT5_base.v -> `included tidied up ctrl_regs.v file; added 'trig_out_en_b' sync reg; automatically IIRs for ATF_BUILD variant
ShiftReg.v -> 'shreg_extract' directive changed to 'equivalent_register_removal' on tap_b (no need for TIGs in UCF)
Timing.v -> change to 'lutcond' to separate logic + retimed
ctrl_regs.v -> tidied up incl. macro statements
ctrl_regs_init_ATF.v -> changed DigIn defaults from "8" to "4"
trigger_divider.v -> TRIG_DISARM feature added